### PR TITLE
Username is null fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/core/rt_manager.js
+++ b/core/rt_manager.js
@@ -7,7 +7,7 @@ const RTMessage = require('./rt_message');
 
 class RTManager {
 	
-	static userCounter=1;
+	static userCounter=0;
 	static userMap=new Map();
 	
 	constructor(port) {
@@ -29,8 +29,10 @@ class RTManager {
 			console.log("connection.remoteAddress->" + connection.remoteAddress);
 			console.log("connection.webSocketVersion->" + connection.webSocketVersion);
 			console.log("connection.connected->" + connection.connected);
-			connection.userCounter=RTManager.userCounter;
+
 			RTManager.userCounter++;
+			connection.userCounter=RTManager.userCounter;
+			console.log("connection.userCounter -> " + connection.userCounter);
 			
 			/*
 			* On Message Event Handler.
@@ -47,7 +49,7 @@ class RTManager {
 				if ( msg.func == "signin") {
 					connection.myuser=msg.userName;
 					RTManager.userMap.set(msg.userName,connection);
-					console.log("siginging in->" + msg.userName);
+					console.log("signing in->" + msg.userName);
 					connection.send(JSON.stringify( { func: 'signinsuccess' , message: 'hello ' + msg.userName + ", we will set you up for location " + msg.userLocation }));
 
 					console.log("sent");
@@ -73,6 +75,8 @@ class RTManager {
 			* On Close Event Handler
 			*/
 			connection.on('close', async function(connection) {
+
+				RTManager.userCounter--;
 				console.log('connection closed->' + JSON.stringify(connection));
 			});
 		});	

--- a/core/rt_message.js
+++ b/core/rt_message.js
@@ -8,7 +8,7 @@
 
 class RTMessage {
 	
-	static messageFuncs=["signin", "sendMessage"];
+	static messageFuncs=["signin", "sendMessage", "close"];
 	
 	constructor() {
 		this.func=null;
@@ -35,7 +35,7 @@ class RTMessage {
 		if ( ! RTMessage.messageFuncs.includes(this.func)) {
 			throw new Error("unknown func->" + this.func);
 		}
-		if ( this.userName == null ) {
+		if ( this.userName == null && this.func != "close" ) {
 			throw new Error("userName is null");
 		}
 		return true;


### PR DESCRIPTION
When a user sends a close func to close the WebSocket, the integrity checker in **rt_message.js** sends an error saying **"unkown func->close"** since close wasn't added to the messageFuncs list. It has now been added.

Then, the integrity checker threw another error, saying that there is no username attached, which was fixed by just allowing the close func to bypass this check, though this may not be a good idea in the long run, since we may want to keep track of who sends the close func, although currently, the JSON format it sends isn't the same as the others (only having the `{"func":"close"}`, which will need to be changed to fit the current format of the other functions.